### PR TITLE
configure.ac: use autotools search functions for GL

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -98,17 +98,18 @@ dnl *******************************************
 dnl OPENGL ************************************
 dnl Figure out which math and GL library to use
 case "$target" in
-    *-*-cygwin* | *-*-mingw32*)
-        MATHLIB=""
-        SYS_GL_LIBS="-lopengl32"
-        ;;	
-    *-*-beos*)
-        MATHLIB=""
-        SYS_GL_LIBS="-lGL"
-        ;;
     *-*-darwin*)
         MATHLIB=""
-        SYS_GL_LIBS=""
+        AC_CHECK_HEADER(
+            [OpenGL/gl.h],
+            [ac_cv_search_glBegin="none required"],
+            [AC_MSG_ERROR(*** OpenGL headers not found on system!)]
+        )
+        AC_CHECK_HEADER(
+            [OpenGL/glu.h],
+            [ac_cv_search_gluScaleImage="none required"],
+            [AC_MSG_ERROR(*** GLU headers not found on system!)]
+        )
         ;;
     *-*-aix*)
         if test x$ac_cv_c_compiler_gnu = xyes; then
@@ -118,34 +119,21 @@ case "$target" in
         ;;
     *)
         MATHLIB="-lm"
-        AC_PATH_X
-        AC_PATH_XTRA
-        if test x$have_x = xyes; then
-            CFLAGS="$CFLAGS $X_CFLAGS"
-            SYS_GL_LIBS="$X_PRE_LIBS $X_LIBS $X_EXTRA_LIBS -lGL -lGLU"
-        else
-            SYS_GL_LIBS="-lGL -lGLU"
-        fi
+        AC_CHECK_HEADER(
+            [GL/gl.h],
+            AC_SEARCH_LIBS(glBegin, [opengl32 GL GL2 OpenGL], [test $ac_cv_search_glBegin = "none required" || GL_LIBS="$ac_cv_search_glBegin $GL_LIBS"], [AC_MSG_ERROR(*** OpenGL library not found on system!)]),
+            [AC_MSG_ERROR(*** OpenGL headers not found on system!)]
+        )
+        AC_CHECK_HEADER(
+            [GL/glu.h],
+            AC_SEARCH_LIBS(gluScaleImage, [glu32 GL GLU], [test $ac_cv_search_gluScaleImage = "none required" || GL_LIBS="$ac_cv_search_gluScaleImage $GL_LIBS"], [AC_MSG_ERROR(*** GLU library not found on system!)]),
+            [AC_MSG_ERROR(*** GLU headers not found on system!)]
+        )
         ;;
 esac
 
 AC_SUBST(MATHLIB)
-
-dnl Check for OpenGL
-AC_MSG_CHECKING(for OpenGL support)
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
-#ifdef WIN32
-#define WINAPI
-#endif
-
- #if defined(__APPLE__) && defined(__MACH__)
- #include <OpenGL/gl.h>
-  #else
- #include <GL/gl.h>
- #endif
-]], [[]])],[],[AC_MSG_ERROR(*** OpenGL not found on system!)])
-AC_MSG_RESULT(yes)
-GL_LIBS="$SYS_GL_LIBS"
+LIBS="$MATHLIB $LIBS"
 AC_SUBST(GL_LIBS)
 LIBS="$GL_LIBS $LIBS"
 


### PR DESCRIPTION
This fixes linking on pure Wayland as it also searches for `-lOpenGL`

Testing:
- [x] Linux without X11
- [x] Linux with X11
- [x] HaikuOS (for the BeOS case) → Broken anyway
- [x] FreeBSD → Broken anyway (needs `make` → `gmake` and then some autotools fixes see https://github.com/lanodan/pinball/commits/bugfix/FreeBSD)

<details>
<summary>Haiku `make` log</summary>
<pre>
make  all-recursive
make[1]: Entering directory '/boot/home/Desktop/Sources/git/github.com/rzr/pinball'
Making all in libltdl
make[2]: Entering directory '/boot/home/Desktop/Sources/git/github.com/rzr/pinball/libltdl'
make  all-am
make[3]: Entering directory '/boot/home/Desktop/Sources/git/github.com/rzr/pinball/libltdl'
make[3]: Leaving directory '/boot/home/Desktop/Sources/git/github.com/rzr/pinball/libltdl'
make[2]: Leaving directory '/boot/home/Desktop/Sources/git/github.com/rzr/pinball/libltdl'
Making all in addon
make[2]: Entering directory '/boot/home/Desktop/Sources/git/github.com/rzr/pinball/addon'
make[2]: Nothing to be done for 'all'.
make[2]: Leaving directory '/boot/home/Desktop/Sources/git/github.com/rzr/pinball/addon'
Making all in base
make[2]: Entering directory '/boot/home/Desktop/Sources/git/github.com/rzr/pinball/base'
make[2]: Nothing to be done for 'all'.
make[2]: Leaving directory '/boot/home/Desktop/Sources/git/github.com/rzr/pinball/base'
Making all in data
make[2]: Entering directory '/boot/home/Desktop/Sources/git/github.com/rzr/pinball/data'
Making all in tux
make[3]: Entering directory '/boot/home/Desktop/Sources/git/github.com/rzr/pinball/data/tux'
make[3]: Nothing to be done for 'all'.
make[3]: Leaving directory '/boot/home/Desktop/Sources/git/github.com/rzr/pinball/data/tux'
Making all in professor
make[3]: Entering directory '/boot/home/Desktop/Sources/git/github.com/rzr/pinball/data/professor'
make[3]: Nothing to be done for 'all'.
make[3]: Leaving directory '/boot/home/Desktop/Sources/git/github.com/rzr/pinball/data/professor'
make[3]: Entering directory '/boot/home/Desktop/Sources/git/github.com/rzr/pinball/data'
make[3]: Nothing to be done for 'all-am'.
make[3]: Leaving directory '/boot/home/Desktop/Sources/git/github.com/rzr/pinball/data'
make[2]: Leaving directory '/boot/home/Desktop/Sources/git/github.com/rzr/pinball/data'
Making all in src
make[2]: Entering directory '/boot/home/Desktop/Sources/git/github.com/rzr/pinball/src'
g++ -DHAVE_CONFIG_H -I. -I.. -I../base -I../addon   -D_REENTRANT -I/packages/libsdl2-2.0.10-1/.self/develop/headers/SDL2  -g -O2 -MT Obj3dsUtil.o -MD -MP -MF .deps/Obj3dsUtil.Tpo -c -o Obj3dsUtil.o Obj3dsUtil.cpp
In file included from /packages/libsdl2-2.0.10-1/.self/develop/headers/SDL2/SDL_stdinc.h:31,
                 from /packages/libsdl2-2.0.10-1/.self/develop/headers/SDL2/SDL_video.h:31,
                 from ../base/TextureUtil.h:19,
                 from ../base/Shape3D.h:26,
                 from Obj3dsUtil.cpp:1057:
/packages/libsdl2-2.0.10-1/.self/develop/headers/SDL2/SDL_config.h:455: warning: "PACKAGE_BUGREPORT" redefined
 #define PACKAGE_BUGREPORT ""
 
In file included from ../base/Private.h:14,
                 from Obj3dsUtil.cpp:13:
../pinconfig.h:190: note: this is the location of the previous definition
 #define PACKAGE_BUGREPORT "henqvist@users.sourceforge.net"
 
In file included from /packages/libsdl2-2.0.10-1/.self/develop/headers/SDL2/SDL_stdinc.h:31,
                 from /packages/libsdl2-2.0.10-1/.self/develop/headers/SDL2/SDL_video.h:31,
                 from ../base/TextureUtil.h:19,
                 from ../base/Shape3D.h:26,
                 from Obj3dsUtil.cpp:1057:
/packages/libsdl2-2.0.10-1/.self/develop/headers/SDL2/SDL_config.h:458: warning: "PACKAGE_NAME" redefined
 #define PACKAGE_NAME ""
 
In file included from ../base/Private.h:14,
                 from Obj3dsUtil.cpp:13:
../pinconfig.h:193: note: this is the location of the previous definition
 #define PACKAGE_NAME "pinball"
 
In file included from /packages/libsdl2-2.0.10-1/.self/develop/headers/SDL2/SDL_stdinc.h:31,
                 from /packages/libsdl2-2.0.10-1/.self/develop/headers/SDL2/SDL_video.h:31,
                 from ../base/TextureUtil.h:19,
                 from ../base/Shape3D.h:26,
                 from Obj3dsUtil.cpp:1057:
/packages/libsdl2-2.0.10-1/.self/develop/headers/SDL2/SDL_config.h:461: warning: "PACKAGE_STRING" redefined
 #define PACKAGE_STRING ""
 
In file included from ../base/Private.h:14,
                 from Obj3dsUtil.cpp:13:
../pinconfig.h:196: note: this is the location of the previous definition
 #define PACKAGE_STRING "pinball 0.3.1"
 
In file included from /packages/libsdl2-2.0.10-1/.self/develop/headers/SDL2/SDL_stdinc.h:31,
                 from /packages/libsdl2-2.0.10-1/.self/develop/headers/SDL2/SDL_video.h:31,
                 from ../base/TextureUtil.h:19,
                 from ../base/Shape3D.h:26,
                 from Obj3dsUtil.cpp:1057:
/packages/libsdl2-2.0.10-1/.self/develop/headers/SDL2/SDL_config.h:464: warning: "PACKAGE_TARNAME" redefined
 #define PACKAGE_TARNAME ""
 
In file included from ../base/Private.h:14,
                 from Obj3dsUtil.cpp:13:
../pinconfig.h:199: note: this is the location of the previous definition
 #define PACKAGE_TARNAME "pinball"
 
In file included from /packages/libsdl2-2.0.10-1/.self/develop/headers/SDL2/SDL_stdinc.h:31,
                 from /packages/libsdl2-2.0.10-1/.self/develop/headers/SDL2/SDL_video.h:31,
                 from ../base/TextureUtil.h:19,
                 from ../base/Shape3D.h:26,
                 from Obj3dsUtil.cpp:1057:
/packages/libsdl2-2.0.10-1/.self/develop/headers/SDL2/SDL_config.h:470: warning: "PACKAGE_VERSION" redefined
 #define PACKAGE_VERSION ""
 
In file included from ../base/Private.h:14,
                 from Obj3dsUtil.cpp:13:
../pinconfig.h:205: note: this is the location of the previous definition
 #define PACKAGE_VERSION "0.3.1"
 
Obj3dsUtil.cpp:309:65: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
                       "Vertex", "Face", "Material" , "Smoothing"};
                                                                 ^
Obj3dsUtil.cpp:309:65: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
Obj3dsUtil.cpp:309:65: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
Obj3dsUtil.cpp:309:65: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
Obj3dsUtil.cpp:309:65: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
Obj3dsUtil.cpp:309:65: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
Obj3dsUtil.cpp:309:65: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
Obj3dsUtil.cpp: In function 'int readScene3dsAscii(FILE*, Scene*)':
Obj3dsUtil.cpp:423:37: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
           str = skipafter( str, "X:"); assert(str);
                                     ^
Obj3dsUtil.cpp:425:37: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
           str = skipafter( str, "Y:"); assert(str);
                                     ^
Obj3dsUtil.cpp:427:37: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
           str = skipafter( str, "Z:"); assert(str);
                                     ^
Obj3dsUtil.cpp:431:37: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
           str = skipafter( str, "U:");
                                     ^
Obj3dsUtil.cpp:433:37: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
           str = skipafter( str, "V:");
                                     ^
Obj3dsUtil.cpp:455:37: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
           str = skipafter( str, "A:"); assert(str);
                                     ^
Obj3dsUtil.cpp:457:37: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
           str = skipafter( str, "B:"); assert(str);
                                     ^
Obj3dsUtil.cpp:459:37: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
           str = skipafter( str, "C:"); assert(str);
                                     ^
Obj3dsUtil.cpp:473:37: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
             str= skipafter( str, ":");
                                     ^
Obj3dsUtil.cpp:485:39: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
               str= skipafter( str, ":");
                                       ^
Obj3dsUtil.cpp: In function 'int saveScene(const Scene*, const char*)':
Obj3dsUtil.cpp:573:29: error: cast from 'FILE*' {aka '_IO_FILE*'} to 'int' loses precision [-fpermissive]
     if ( ! f ) return (int) f;
                             ^
Obj3dsUtil.cpp: In function 'int saveObject(const Object*, const char*)':
Obj3dsUtil.cpp:588:29: error: cast from 'FILE*' {aka '_IO_FILE*'} to 'int' loses precision [-fpermissive]
     if ( ! f ) return (int) f;
                             ^
Obj3dsUtil.cpp: In function 'int parse3dsAscii(FILE*, Object*)':
Obj3dsUtil.cpp:668:37: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
           str = skipafter( str, "X:"); assert(str);
                                     ^
Obj3dsUtil.cpp:670:37: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
           str = skipafter( str, "Y:"); assert(str);
                                     ^
Obj3dsUtil.cpp:672:37: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
           str = skipafter( str, "Z:"); assert(str);
                                     ^
Obj3dsUtil.cpp:689:37: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
           str = skipafter( str, "A:"); assert(str);
                                     ^
Obj3dsUtil.cpp:691:37: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
           str = skipafter( str, "B:"); assert(str);
                                     ^
Obj3dsUtil.cpp:693:37: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
           str = skipafter( str, "C:"); assert(str);
                                     ^
Obj3dsUtil.cpp:703:37: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
             str= skipafter( str, ":");
                                     ^
Obj3dsUtil.cpp:711:37: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
             str= skipafter( str, ":");
                                     ^
Obj3dsUtil.cpp: In function 'int convertColorRGBFloatToString(float, float, float, float, char*)':
Obj3dsUtil.cpp:840:10: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
     dest="r255g255b255a000";
          ^~~~~~~~~~~~~~~~~~
/packages/libsdl2-2.0.10-1/.self/develop/headers/SDL2/SDL_stdinc.h: At global scope:
Obj3dsUtil.cpp:90:25: error: multiple types in one declaration
 #define Uint32 unsigned int
                         ^~~
/packages/libsdl2-2.0.10-1/.self/develop/headers/SDL2/SDL_stdinc.h:203:18: note: in expansion of macro 'Uint32'
 typedef uint32_t Uint32;
                  ^~~~~~
Obj3dsUtil.cpp:90:25: error: declaration does not declare anything [-fpermissive]
 #define Uint32 unsigned int
                         ^~~
/packages/libsdl2-2.0.10-1/.self/develop/headers/SDL2/SDL_stdinc.h:203:18: note: in expansion of macro 'Uint32'
 typedef uint32_t Uint32;
                  ^~~~~~
Makefile:589: recipe for target 'Obj3dsUtil.o' failed
make[2]: *** [Obj3dsUtil.o] Error 1
make[2]: Leaving directory '/boot/home/Desktop/Sources/git/github.com/rzr/pinball/src'
Makefile:535: recipe for target 'all-recursive' failed
make[1]: *** [all-recursive] Error 1
make[1]: Leaving directory '/boot/home/Desktop/Sources/git/github.com/rzr/pinball'
Makefile:409: recipe for target 'all' failed
make: *** [all] Error 2
</pre></details>

Note: Doesn't fixes the black/blank window in `libX11`-less Wayland.

Sorry MS Windows, AppleOS and AIX, can't really test those.

Less experimental but janky alternative to this PR:
```diff
commit b5a301a407759899586b15377f07f65176e98a62
Author: Haelwenn (lanodan) Monnier <contact@hacktivis.me>
Date:   2020-12-15T06:14:52 GMT

    Fix GL linking on pure wayland

diff --git a/configure.ac b/configure.ac
index ecc41d0..b6fcb2c 100644
--- a/configure.ac
+++ b/configure.ac
@@ -124,7 +124,8 @@ case "$target" in
             CFLAGS="$CFLAGS $X_CFLAGS"
             SYS_GL_LIBS="$X_PRE_LIBS $X_LIBS $X_EXTRA_LIBS -lGL -lGLU"
         else
-            SYS_GL_LIBS="-lGL -lGLU"
+            # Assume that libglvnd is used when X isn't
+            SYS_GL_LIBS="-lOpenGL -lGLU"
         fi
         ;;
 esac
```