### PR TITLE
Remove the inclusion of <filesystem>

### DIFF
--- a/base/Config.cpp
+++ b/base/Config.cpp
@@ -12,7 +12,6 @@
 #include "EMath.h"
 
 #include <cstdio>
-#include <filesystem>
 #include <fstream>
 #include <iostream>
 


### PR DESCRIPTION
This change removes the inclusion of <filesystem>: this is not used and requires at least GCC 8

Nicolas Caramelli