### PR TITLE
autoconf: Use AS_HELP_STRING on AC_ARG_{WITH,ENABLE}

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -18,19 +18,19 @@ AC_DEFUN([AM_PATH_SDL2],
 dnl Get the cflags and libraries from the sdl2-config script
 dnl
 AC_ARG_WITH(sdl-prefix,
-	[  --with-sdl-prefix=PFX   Prefix where SDL is installed (optional)],
+	[AS_HELP_STRING([--with-sdl-prefix=PFX], [Prefix where SDL is installed (optional)])],
 	sdl_prefix="$withval",
 	sdl_prefix="")
 AC_ARG_WITH(sdl-exec-prefix,
-	[  --with-sdl-exec-prefix=PFX Exec prefix where SDL is installed (optional)],
+	[AS_HELP_STRING([--with-sdl-exec-prefix=PFX], [Exec prefix where SDL is installed (optional)])],
 	sdl_exec_prefix="$withval",
 	sdl_exec_prefix="")
 AC_ARG_ENABLE(sdltest,
-	[  --disable-sdltest       Do not try to compile and run a test SDL program],
+	[AS_HELP_STRING([--disable-sdltest], [Do not try to compile and run a test SDL program])],
 	,
 	enable_sdltest=yes)
 AC_ARG_ENABLE(sdlframework,
-	[  --disable-sdlframework Do not search for SDL2.framework],
+	[AS_HELP_STRING([--disable-sdlframework], [Do not search for SDL2.framework])],
 	,
 	search_sdl_framework=yes)
 
@@ -252,11 +252,11 @@ AC_DEFUN([AM_PATH_CPPUNIT],
 [
 
 AC_ARG_WITH(cppunit-prefix,
-	[  --with-cppunit-prefix=PFX   Prefix where CppUnit is installed (optional)],
+	[AS_HELP_STRING([--with-cppunit-prefix=PFX], [Prefix where CppUnit is installed (optional)])],
 	cppunit_config_prefix="$withval",
 	cppunit_config_prefix="")
 AC_ARG_WITH(cppunit-exec-prefix,
-	[  --with-cppunit-exec-prefix=PFX  Exec prefix where CppUnit is installed (optional)],
+	[AS_HELP_STRING([--with-cppunit-exec-prefix=PFX ], [Exec prefix where CppUnit is installed (optional)])],
 	cppunit_config_exec_prefix="$withval",
 	cppunit_config_exec_prefix="")
 
@@ -343,17 +343,17 @@ AC_DEFUN([AM_PATH_ALLEGRO],
 dnl Get the cflags and libraries from the allegro-config script
 dnl
 AC_ARG_WITH(allegro-prefix,
-	[  --with-allegro-prefix=PFX   Prefix where Allegro is installed (optional)],
+	[AS_HELP_STRING([--with-allegro-prefix=PFX], [Prefix where Allegro is installed (optional)])],
 	allegro_prefix="$withval",
 	allegro_prefix="")
 
 AC_ARG_WITH(allegro-exec-prefix,
-	[  --with-allegro-exec-prefix=PFX Exec prefix where Allegro is installed (optional)],
+	[AS_HELP_STRING([--with-allegro-exec-prefix=PFX], [Exec prefix where Allegro is installed (optional)])],
 	allegro_exec_prefix="$withval",
 	allegro_exec_prefix="")
 
 AC_ARG_ENABLE(allegrotest,
-	[  --disable-allegrotest       Do not try to compile and run a test Allegro program],
+	[AS_HELP_STRING([--disable-allegrotest], [Do not try to compile and run a test Allegro program])],
 	,
 	enable_allegrotest=yes)
 

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -17,14 +17,22 @@ AC_DEFUN([AM_PATH_SDL2],
 [dnl 
 dnl Get the cflags and libraries from the sdl2-config script
 dnl
-AC_ARG_WITH(sdl-prefix,[  --with-sdl-prefix=PFX   Prefix where SDL is installed (optional)],
-            sdl_prefix="$withval", sdl_prefix="")
-AC_ARG_WITH(sdl-exec-prefix,[  --with-sdl-exec-prefix=PFX Exec prefix where SDL is installed (optional)],
-            sdl_exec_prefix="$withval", sdl_exec_prefix="")
-AC_ARG_ENABLE(sdltest, [  --disable-sdltest       Do not try to compile and run a test SDL program],
-		    , enable_sdltest=yes)
-AC_ARG_ENABLE(sdlframework, [  --disable-sdlframework Do not search for SDL2.framework],
-        , search_sdl_framework=yes)
+AC_ARG_WITH(sdl-prefix,
+	[  --with-sdl-prefix=PFX   Prefix where SDL is installed (optional)],
+	sdl_prefix="$withval",
+	sdl_prefix="")
+AC_ARG_WITH(sdl-exec-prefix,
+	[  --with-sdl-exec-prefix=PFX Exec prefix where SDL is installed (optional)],
+	sdl_exec_prefix="$withval",
+	sdl_exec_prefix="")
+AC_ARG_ENABLE(sdltest,
+	[  --disable-sdltest       Do not try to compile and run a test SDL program],
+	,
+	enable_sdltest=yes)
+AC_ARG_ENABLE(sdlframework,
+	[  --disable-sdlframework Do not search for SDL2.framework],
+	,
+	search_sdl_framework=yes)
 
 AC_ARG_VAR(SDL2_FRAMEWORK, [Path to SDL2.framework])
 
@@ -243,10 +251,14 @@ dnl
 AC_DEFUN([AM_PATH_CPPUNIT],
 [
 
-AC_ARG_WITH(cppunit-prefix,[  --with-cppunit-prefix=PFX   Prefix where CppUnit is installed (optional)],
-            cppunit_config_prefix="$withval", cppunit_config_prefix="")
-AC_ARG_WITH(cppunit-exec-prefix,[  --with-cppunit-exec-prefix=PFX  Exec prefix where CppUnit is installed (optional)],
-            cppunit_config_exec_prefix="$withval", cppunit_config_exec_prefix="")
+AC_ARG_WITH(cppunit-prefix,
+	[  --with-cppunit-prefix=PFX   Prefix where CppUnit is installed (optional)],
+	cppunit_config_prefix="$withval",
+	cppunit_config_prefix="")
+AC_ARG_WITH(cppunit-exec-prefix,
+	[  --with-cppunit-exec-prefix=PFX  Exec prefix where CppUnit is installed (optional)],
+	cppunit_config_exec_prefix="$withval",
+	cppunit_config_exec_prefix="")
 
   if test x$cppunit_config_exec_prefix != x ; then
      cppunit_config_args="$cppunit_config_args --exec-prefix=$cppunit_config_exec_prefix"
@@ -330,11 +342,20 @@ AC_DEFUN([AM_PATH_ALLEGRO],
 [dnl 
 dnl Get the cflags and libraries from the allegro-config script
 dnl
-AC_ARG_WITH(allegro-prefix,[  --with-allegro-prefix=PFX   Prefix where Allegro is installed (optional)], allegro_prefix="$withval", allegro_prefix="")
+AC_ARG_WITH(allegro-prefix,
+	[  --with-allegro-prefix=PFX   Prefix where Allegro is installed (optional)],
+	allegro_prefix="$withval",
+	allegro_prefix="")
 
-AC_ARG_WITH(allegro-exec-prefix,[  --with-allegro-exec-prefix=PFX Exec prefix where Allegro is installed (optional)], allegro_exec_prefix="$withval", allegro_exec_prefix="")
+AC_ARG_WITH(allegro-exec-prefix,
+	[  --with-allegro-exec-prefix=PFX Exec prefix where Allegro is installed (optional)],
+	allegro_exec_prefix="$withval",
+	allegro_exec_prefix="")
 
-AC_ARG_ENABLE(allegrotest, [  --disable-allegrotest       Do not try to compile and run a test Allegro program], , enable_allegrotest=yes)
+AC_ARG_ENABLE(allegrotest,
+	[  --disable-allegrotest       Do not try to compile and run a test Allegro program],
+	,
+	enable_allegrotest=yes)
 
   if test x$allegro_exec_prefix != x ; then
      allegro_args="$allegro_args --exec-prefix=$allegro_exec_prefix"

--- a/configure.ac
+++ b/configure.ac
@@ -21,11 +21,11 @@ dnl CFLAGS="-g -W -Wall -O2"
 dnl CXXFLAGS="-g -W -Wall -O2"
 
 AC_ARG_WITH(cflags,
-	[  --with-cflags=CFLAGS            use CFLAGS as compile time arguments.],
+	[AS_HELP_STRING([--with-cflags=CFLAGS], [use CFLAGS as compile time arguments.])],
 	[CFLAGS=$with_cflags; export CFLAGS])
 
 AC_ARG_WITH(cxxflags,
-	[  --with-cxxflags=CXXFLAGS        use CXXFLAGS as compile time arguments.],
+	[AS_HELP_STRING([--with-cxxflags=CXXFLAGS], [use CXXFLAGS as compile time arguments.])],
 	[CXXFLAGS=$with_cxxflags; export CXXFLAGS])
 
 dnl Checks for programs.
@@ -67,7 +67,7 @@ AC_DEFINE_UNQUOTED(EM_LIBDIR, "$EM_LIBPATH", [The library or plugin dir /usr/loc
 
 dnl special fix for rpmbuild, I hate rpmbuild even more than I hate autoconf
 AC_ARG_WITH(buildroot-prefix,
-	[  --with-buildroot-prefix=PFX    Only used when building packages],
+	[AS_HELP_STRING([--with-buildroot-prefix=PFX], [Only used when building packages])],
 	buildroot_prefix="$withval",
 	buildroot_prefix="")
 
@@ -79,7 +79,7 @@ fi
 AC_SUBST(EM_BUILD_ROOT)
 
 AC_ARG_WITH(highscore-prefix,
-	[  --with-highscore-prefix=PFX    Install highscore files in PFX (/var/games/pinball)],
+	[AS_HELP_STRING([--with-highscore-prefix=PFX], [Install highscore files in PFX (/var/games/pinball)])],
 	highscore_prefix="$withval",
 	highscore_prefix="")
 
@@ -96,7 +96,7 @@ AC_DEFINE_UNQUOTED(EM_HIGHSCORE_DIR, "$EM_HIGHSCORE_PATH", [Highscore directory]
 
 
 AC_ARG_ENABLE(libtest,
-	[  --disable-libtest       SDL_image _mixer libtest work around ],
+	[AS_HELP_STRING([--disable-libtest],[SDL_image _mixer libtest work around ])],
 	,
 	enable_libtest=yes)
 
@@ -104,7 +104,7 @@ dnl *******************************************
 dnl Allegro or SDL version ********************
 
 AC_ARG_WITH(allegro,
-	[  --with-allegro          use allegro (software rendering) instead of SDL and OpenGL],
+	[AS_HELP_STRING([--with-allegro],[use allegro (software rendering) instead of SDL and OpenGL])],
 	use_allegro="yes",
 	use_allegro="no")
 
@@ -116,7 +116,7 @@ dnl *******************************************
 dnl OPENGL ************************************
 dnl Figure out which math and GL library to use
 
-AC_ARG_ENABLE(gles, [  --enable-gles           Enable OpenGL ES])
+AC_ARG_ENABLE(gles, [AS_HELP_STRING([--enable-gles],[Enable OpenGL ES])])
 if test "x$enable_gles" = "xyes"; then
   MATHLIB="-lm"
   AC_CHECK_HEADER(
@@ -125,7 +125,7 @@ if test "x$enable_gles" = "xyes"; then
       [AC_MSG_ERROR(*** OpenGL ES headers not found on system!)]
   )
   AC_ARG_WITH(gles-library,
-  	[  --with-gles-library=LIBRARY OpenGL ES library @<:@default=GLESv1_CM@:>@],
+  	[AS_HELP_STRING([--with-gles-library=LIBRARY],[OpenGL ES library @<:@default=GLESv1_CM@:>@])],
   	GL_LIBS=-l"$withval",
   	GL_LIBS="-lGLESv1_CM")
   AC_DEFINE(HAVE_OPENGLES, [1], [Support for OpenGL ES])
@@ -176,7 +176,7 @@ DEP_PKGS="$DEP_PKGS sdl2 >= 2.0.0"
 
 dnl SDL_image *********************************
 AC_ARG_WITH(sdl2image-prefix,
-	[  --with-sdl2image-prefix=PFX prefix where SDL2_image library is installed],
+	[AS_HELP_STRING([--with-sdl2image-prefix=PFX], [prefix where SDL2_image library is installed])],
 	sdl2image_prefix="$withval",
 	sdl2image_prefix="")
 
@@ -203,7 +203,7 @@ fi
 
 dnl SDL_mixer **********************************
 AC_ARG_WITH(sdl2mixer-prefix,
-	[  --with-sdl2mixer-prefix=PFX prefix where SDL2_mixer library is installed],
+	[AS_HELP_STRING([--with-sdl2mixer-prefix=PFX],[prefix where SDL2_mixer library is installed])],
 	sdl2mixer_prefix="$withval",
 	sdl2mixer_prefix="")
 
@@ -241,7 +241,7 @@ dnl ********************************************
 dnl CPP_UNIT ***********************************
 
 AC_ARG_WITH(unittest,
-	[  --with-unittest         Try to use unitest],
+	[AS_HELP_STRING([--with-unittest],[Try to use unitest])],
 	use_unittest="yes",
 	use_unittest="no")
 
@@ -266,7 +266,7 @@ AC_CHECK_HEADERS(sys/types.h, : ,AC_MSG_ERROR([*** Header sys/types.h not found.
 dnl ********************************************
 dnl Debug and Config ***************************
 AC_ARG_WITH(debug,
-	[  --with-debug            Compile debug version],
+	[AS_HELP_STRING([--with-debug],[Compile debug version])],
 	use_debug="yes",
 	use_debug="no")
 
@@ -275,7 +275,7 @@ AC_DEFINE(EM_DEBUG, [1], [Shall we use debug features such as profiling and keyb
 fi
 
 AC_ARG_WITH(trako,
-	[  --with-trako            Compile trako version],
+	[AS_HELP_STRING([--with-trako],[Compile trako version])],
 	use_trako="yes",
 	use_trako="no")
 if test x"$use_trako" = "xyes"; then

--- a/configure.ac
+++ b/configure.ac
@@ -21,12 +21,12 @@ dnl CFLAGS="-g -W -Wall -O2"
 dnl CXXFLAGS="-g -W -Wall -O2"
 
 AC_ARG_WITH(cflags,
-[  --with-cflags=CFLAGS            use CFLAGS as compile time arguments.],
-    [CFLAGS=$with_cflags; export CFLAGS])
+	[  --with-cflags=CFLAGS            use CFLAGS as compile time arguments.],
+	[CFLAGS=$with_cflags; export CFLAGS])
 
 AC_ARG_WITH(cxxflags,
-[  --with-cxxflags=CXXFLAGS        use CXXFLAGS as compile time arguments.],
-    [CXXFLAGS=$with_cxxflags; export CXXFLAGS])
+	[  --with-cxxflags=CXXFLAGS        use CXXFLAGS as compile time arguments.],
+	[CXXFLAGS=$with_cxxflags; export CXXFLAGS])
 
 dnl Checks for programs.
 AC_PROG_CC
@@ -66,7 +66,10 @@ AC_DEFINE_UNQUOTED(EM_LIBDIR, "$EM_LIBPATH", [The library or plugin dir /usr/loc
 
 
 dnl special fix for rpmbuild, I hate rpmbuild even more than I hate autoconf
-AC_ARG_WITH(buildroot-prefix, [  --with-buildroot-prefix=PFX    Only used when building packages], buildroot_prefix="$withval", buildroot_prefix="")
+AC_ARG_WITH(buildroot-prefix,
+	[  --with-buildroot-prefix=PFX    Only used when building packages],
+	buildroot_prefix="$withval",
+	buildroot_prefix="")
 
 if test x"$buildroot_prefix" != "x"; then
 	EM_BUILD_ROOT=$buildroot_prefix
@@ -75,7 +78,10 @@ else
 fi
 AC_SUBST(EM_BUILD_ROOT)
 
-AC_ARG_WITH(highscore-prefix, [  --with-highscore-prefix=PFX    Install highscore files in PFX (/var/games/pinball)], highscore_prefix="$withval", highscore_prefix="")
+AC_ARG_WITH(highscore-prefix,
+	[  --with-highscore-prefix=PFX    Install highscore files in PFX (/var/games/pinball)],
+	highscore_prefix="$withval",
+	highscore_prefix="")
 
 if test x"$highscore_prefix" != "x"; then
 	EM_HIGHSCORE_DIR=$highscore_prefix
@@ -89,12 +95,18 @@ eval EM_HIGHSCORE_PATH=`eval echo "$EM_HIGHSCORE_DIR"`
 AC_DEFINE_UNQUOTED(EM_HIGHSCORE_DIR, "$EM_HIGHSCORE_PATH", [Highscore directory])
 
 
-AC_ARG_ENABLE(libtest, [  --disable-libtest       SDL_image _mixer libtest work around ], , enable_libtest=yes)
+AC_ARG_ENABLE(libtest,
+	[  --disable-libtest       SDL_image _mixer libtest work around ],
+	,
+	enable_libtest=yes)
 
 dnl *******************************************
 dnl Allegro or SDL version ********************
 
-AC_ARG_WITH(allegro, [  --with-allegro          use allegro (software rendering) instead of SDL and OpenGL], use_allegro="yes", use_allegro="no")
+AC_ARG_WITH(allegro,
+	[  --with-allegro          use allegro (software rendering) instead of SDL and OpenGL],
+	use_allegro="yes",
+	use_allegro="no")
 
 if test x"$use_allegro" = "xno"; then
 
@@ -112,7 +124,10 @@ if test "x$enable_gles" = "xyes"; then
       [ac_cv_search_glLoadMatrixx="none required"],
       [AC_MSG_ERROR(*** OpenGL ES headers not found on system!)]
   )
-  AC_ARG_WITH(gles-library, [  --with-gles-library=LIBRARY OpenGL ES library @<:@default=GLESv1_CM@:>@], GL_LIBS=-l"$withval", GL_LIBS="-lGLESv1_CM")
+  AC_ARG_WITH(gles-library,
+  	[  --with-gles-library=LIBRARY OpenGL ES library @<:@default=GLESv1_CM@:>@],
+  	GL_LIBS=-l"$withval",
+  	GL_LIBS="-lGLESv1_CM")
   AC_DEFINE(HAVE_OPENGLES, [1], [Support for OpenGL ES])
 else
 case "$target" in
@@ -160,7 +175,10 @@ LIBS="$LIBS $SDL_LIBS"
 DEP_PKGS="$DEP_PKGS sdl2 >= 2.0.0"
 
 dnl SDL_image *********************************
-AC_ARG_WITH(sdl2image-prefix, [  --with-sdl2image-prefix=PFX prefix where SDL2_image library is installed], sdl2image_prefix="$withval", sdl2image_prefix="") 
+AC_ARG_WITH(sdl2image-prefix,
+	[  --with-sdl2image-prefix=PFX prefix where SDL2_image library is installed],
+	sdl2image_prefix="$withval",
+	sdl2image_prefix="")
 
 if test x"$sdl2image_prefix" != "x"; then
   SDL2IMAGE_LIB="-L$sdl2image_prefix/lib"
@@ -184,7 +202,10 @@ if test x"$enable_libtest" = x"yes"; then
 fi
 
 dnl SDL_mixer **********************************
-AC_ARG_WITH(sdl2mixer-prefix, [  --with-sdl2mixer-prefix=PFX prefix where SDL2_mixer library is installed], sdl2mixer_prefix="$withval", sdl2mixer_prefix="")
+AC_ARG_WITH(sdl2mixer-prefix,
+	[  --with-sdl2mixer-prefix=PFX prefix where SDL2_mixer library is installed],
+	sdl2mixer_prefix="$withval",
+	sdl2mixer_prefix="")
 
 if test x"$sdl2mixer_prefix" != "x"; then
   SDL2MIXER_LIB="-L$sdl2mixer_prefix/lib"
@@ -219,7 +240,10 @@ dnl End Allegro or SDL *************************
 dnl ********************************************
 dnl CPP_UNIT ***********************************
 
-AC_ARG_WITH(unittest, [  --with-unittest         Try to use unitest], use_unittest="yes", use_unittest="no")
+AC_ARG_WITH(unittest,
+	[  --with-unittest         Try to use unitest],
+	use_unittest="yes",
+	use_unittest="no")
 
 if test x"$use_unittest" = "xyes"; then
 
@@ -241,13 +265,19 @@ AC_CHECK_HEADERS(sys/types.h, : ,AC_MSG_ERROR([*** Header sys/types.h not found.
 
 dnl ********************************************
 dnl Debug and Config ***************************
-AC_ARG_WITH(debug, [  --with-debug            Compile debug version], use_debug="yes", use_debug="no")
+AC_ARG_WITH(debug,
+	[  --with-debug            Compile debug version],
+	use_debug="yes",
+	use_debug="no")
 
 if test x"$use_debug" = "xyes"; then
 AC_DEFINE(EM_DEBUG, [1], [Shall we use debug features such as profiling and keyboard ball steering])
 fi
 
-AC_ARG_WITH(trako, [  --with-trako            Compile trako version], use_trako="yes", use_trako="no")
+AC_ARG_WITH(trako,
+	[  --with-trako            Compile trako version],
+	use_trako="yes",
+	use_trako="no")
 if test x"$use_trako" = "xyes"; then
 AC_DEFINE(EM_TRAKO, [1], [Shall we use trako features such as profiling and keyboard ball steering])
 fi


### PR DESCRIPTION
Thanks GNU auto*hell for this "better is worse" paragdimn.

This allows to have correct alignment in `--help` output.

First commit is #29 to avoid doing extraneous conflicts.