### PR TITLE
Autotools: Reuse system libtool installation

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,6 @@
 AUTOMAKE_OPTIONS = gnu
 
-SUBDIRS = libltdl addon base data src test
+SUBDIRS = addon base data src test
 
 EXTRA_DIST = bootstrap pinball.spec clean pinball.desktop
 

--- a/configure.ac
+++ b/configure.ac
@@ -9,7 +9,6 @@ AC_INIT([pinball],
 
 AC_CONFIG_MACRO_DIRS([libltdl/m4])
 AM_CONFIG_HEADER(pinconfig.h)
-LT_CONFIG_LTDL_DIR([libltdl])
 
 AC_CANONICAL_HOST
 AC_CANONICAL_TARGET
@@ -33,15 +32,8 @@ AC_PROG_CC
 AM_PROG_AR
 AC_PROG_CXX
 AC_PROG_INSTALL
-_LT_SET_OPTION([LT_INIT],[dlopen])
-AC_DIAGNOSE([obsolete],[AC_LIBTOOL_DLOPEN: Remove this warning and the call to _LT_SET_OPTION when you
-put the 'dlopen' option into LT_INIT's first parameter.])
 
-LT_INIT
-LTDL_INIT
-
-AC_SUBST(INCLTDL)
-AC_SUBST(LIBLTDL)
+LT_INIT([dlopen])
 
 dnl *******************************************
 dnl PATHS AND DIRS ****************************

--- a/helper.mk
+++ b/helper.mk
@@ -166,7 +166,7 @@ config.status configure: acinclude.m4 pinconfig.h.in Makefile.in
 
 INSTALL config.guess config.sub depcomp install-sh autom4te.cache: Makefile.am ltmain.sh pinconfig.h.in README
 	@echo "# log: $@: $^"
-	automake --add-missing --copy --force
+	automake --add-missing --copy
 	stat -c '%y: %n' $^ $@
 
 README: README.md
@@ -198,7 +198,7 @@ pinconfig.h.in: aclocal.m4
 
 libltdl/m4 compile missing ltmain.sh: configure.ac
 	@echo "# log: $@: $<"
-	libtoolize --ltdl --force --copy
+	libtoolize --force
 	stat -c '%y: %n' $^ $@
 
 devel: ${app}

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -7,9 +7,9 @@ bin_PROGRAMS = pinball
 
 pinlib_LIBRARIES = libemilia_pin.a
 
-AM_CPPFLAGS = -I../base -I../addon @INCLTDL@
+AM_CPPFLAGS = -I../base -I../addon
 
-pinball_LDADD = libemilia_pin.a ../addon/libemilia_addon.a ../base/libemilia_base.a @LIBLTDL@
+pinball_LDADD = libemilia_pin.a ../addon/libemilia_addon.a ../base/libemilia_base.a -lltdl
 pinball_LDFLAGS = -export-dynamic
 
 pinball_SOURCES = Pinball.cpp

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -6,8 +6,8 @@ testdatadir = $(pkgdatadir)
 noinst_PROGRAMS = scale simple light texture load explode collision signal billboard font thread menu joy sound trans math misc varray unittest
 # noinst_PROGRAMS = unittest
 
-AM_CPPFLAGS = -I../base -I../addon -I../src @INCLTDL@
-LDADD = ../src/libemilia_pin.a ../addon/libemilia_addon.a ../base/libemilia_base.a @LIBLTDL@
+AM_CPPFLAGS = -I../base -I../addon -I../src
+LDADD = ../src/libemilia_pin.a ../addon/libemilia_addon.a ../base/libemilia_base.a -lltdl
 
 testlib_LTLIBRARIES = libModuleTest.la
 


### PR DESCRIPTION
This is a forward-port of gentoo's packaging of legacy emilia-pinball[1]

1: https://github.com/gentoo/gentoo/blob/794a3fc70095a5b58835bfc50926bf788900fe68/games-arcade/emilia-pinball/files/emilia-pinball-0.3.1-libtool.patch
