### PR TITLE
configure.ac: Use AC_CONFIG_HEADERS instead of the obsolete AM_CONFIG_HEADER

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -8,7 +8,7 @@ AC_INIT([pinball],
 	[https://pinball.sf.net])
 
 AC_CONFIG_MACRO_DIRS([libltdl/m4])
-AM_CONFIG_HEADER(pinconfig.h)
+AC_CONFIG_HEADERS(pinconfig.h)
 
 AC_CANONICAL_HOST
 AC_CANONICAL_TARGET


### PR DESCRIPTION
Reference: https://www.gnu.org/software/automake/manual/1.12.6/html_node/Obsolete-Macros.html